### PR TITLE
Updates to HyperShift chart

### DIFF
--- a/charts/all/hypershift/templates/multiclusterengine.yaml
+++ b/charts/all/hypershift/templates/multiclusterengine.yaml
@@ -6,33 +6,12 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-5"
 spec:
-  availabilityConfig: High
+  availabilityConfig: {{ .Values.mce.availabilityConfig }}
   overrides:
     components:
-    - enabled: true
-      name: assisted-service
-    - enabled: true
-      name: cluster-lifecycle
-    - enabled: true
-      name: cluster-manager
-    - enabled: true
-      name: discovery
-    - enabled: true
-      name: hive
-    - enabled: true
-      name: server-foundation
-    - enabled: true
-      name: cluster-proxy-addon
-    - enabled: true
-      name: local-cluster
-    - enabled: true
-      name: hypershift-local-hosting
-    - enabled: true
-      name: managedserviceaccount
-    - enabled: true
-      name: hypershift
-    - enabled: true
-      name: console-mce
-    - enabled: false
-      name: image-based-install-operator-preview
-  targetNamespace: multicluster-engine
+    {{- range .Values.mce.components  }}
+      - name: {{ .name }}
+        enabled: {{ .enabled | default "true" }}
+        configOverrides: {}
+    {{- end }}
+  targetNamespace: {{ .Values.mce.targetNS }}

--- a/charts/all/hypershift/values.yaml
+++ b/charts/all/hypershift/values.yaml
@@ -39,3 +39,23 @@ global:
     bucketName: 
 
 # End global parameters
+
+# MultiCluster Engine Components
+mce:
+  targetNS: multicluster-engine
+  availabilityConfig: High
+  components:
+    - name: image-based-install-operator-preview
+      enabled: "false"
+    - name: assisted-service
+    - name: cluster-lifecycle
+    - name: cluster-manager
+    - name: discovery
+    - name: hive
+    - name: server-foundation
+    - name: cluster-proxy-addon
+    - name: local-cluster
+    - name: hypershift-local-hosting
+    - name: managedserviceaccount
+    - name: hypershift
+    - name: console-mce


### PR DESCRIPTION
The operator update for multicluster engine 2.7 has the argo application showing `out of sync` because of a new parameter. To resolve, I updated the template to add the parameter in, as well as making the following changes:

- Updates add configOverrides{} dictionary for 2.7 update.
- Moved mce components under values to keep template tidy and overrides in single location