### PR TITLE
removing -preview from mce component

### DIFF
--- a/charts/all/hypershift/values.yaml
+++ b/charts/all/hypershift/values.yaml
@@ -45,7 +45,7 @@ mce:
   targetNS: multicluster-engine
   availabilityConfig: High
   components:
-    - name: image-based-install-operator-preview
+    - name: image-based-install-operator
       enabled: "false"
     - name: assisted-service
     - name: cluster-lifecycle


### PR DESCRIPTION
The operator update for multicluster engine 2.7 has the argo application showing `out of sync` because of a new parameter. To resolve, I updated the template to add the parameter in, as well as making the following changes:

- `-preview` on component: `image-based-install-operator-preview` is no longer necessary.