### PR TITLE
updated rbac in cluster role

### DIFF
--- a/charts/all/hypershift/templates/rbac/hcp-admin-crole.yaml
+++ b/charts/all/hypershift/templates/rbac/hcp-admin-crole.yaml
@@ -58,4 +58,19 @@ rules:
   - endpoints
   verbs:
   - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
 {{- end }}


### PR DESCRIPTION
Updated permissions in rbac to include:

- allow for read (get,list) clusterversions in `config.openshift.io` apiGroup
- allow for read (get,list,watch) all resources in `argoproj.io` apiGroup

This lets the hcp clusterRole view basic information on some cluster resources w/out requiring `kubeadmin`