### PR TITLE
Fix the hcp-cli application

### DIFF
--- a/values-staging.yaml
+++ b/values-staging.yaml
@@ -25,9 +25,10 @@ clusterGroup:
       namespace: multicluster-engine
       channel: stable-2.11
     
-  projects:
+  argoProjects:
     - hub
     - hypershift
+    - infrastructure
 
   applications:
     vault:


### PR DESCRIPTION
 The hcp-cli Application (in hypershift-staging namespace) is configured
 with project: infrastructure, but no ArgoCD AppProject named
 infrastructure exists in the cluster, let's add it.

 Observed on https://jenkins-csb-mpqe-mps.dno.corp.redhat.com/job/ValidatedPatterns/job/Hypershift/job/hypershift-aws-ocp4.21-interop/13/consoleFull
