### PR TITLE
feat: Add engineering grp to sudoer groups

### DIFF
--- a/values-hypershift.yaml
+++ b/values-hypershift.yaml
@@ -1,5 +1,5 @@
-# Override values for HyperShift 
-# Define the s3 bucket information  
+# Override values for HyperShift
+# Define the s3 bucket information
 global:
   hypershift:
     createBucket: true
@@ -75,7 +75,7 @@ autoscaling:
   #   enabled: true
   #   machineSetName: <cluster-name>-worker-<zone>
   #   minReplicas: 0
-  #   maxReplicas: 6  
+  #   maxReplicas: 6
 
 # Set rbac.create to false if you want to skip creation of role/rolebinding.
 rbac:
@@ -83,3 +83,5 @@ rbac:
 # Provide a list of users and/or groups to add to the clusterrolebinding
   users: []
   groups: []
+  sudoerGroups:
+  - Engineering


### PR DESCRIPTION
The group members will have the right to impersonate system:admin.
