### PR TITLE
Add cluster-provisioning namespace

### DIFF
--- a/values-staging.yaml
+++ b/values-staging.yaml
@@ -13,6 +13,7 @@ clusterGroup:
       targetNamespaces: []
     external-secrets:
     multicluster-engine:
+    cluster-provisioning:
 
   subscriptions:
     eso:


### PR DESCRIPTION
The hcp-cli ArgoCD application is configured to deploy its resources
into the cluster-provisioning namespace (see spec.destination.namespace:
cluster-provisioning), but that namespace was never created on the
cluster.

Every resource the app tried to sync failed with the same error:

▎ namespaces "cluster-provisioning" not found

Fixes: https://redhat.atlassian.net/browse/MBP-1129
